### PR TITLE
Fix FoursquareTemplate to accept Userless Access

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@
 # version to be applied to all projects in this multi-project build. this is
 # the one and only location version changes need to be made.
 # ------------------------------------------------------------------------------
-springSocialFoursquareVersion=1.0.8.RELEASE
+springSocialFoursquareVersion=1.0.9.SNAPSHOT
 
 # ------------------------------------------------------------------------------
 # build system user roles

--- a/spring-social-foursquare/src/main/java/org/springframework/social/foursquare/api/impl/FoursquareTemplate.java
+++ b/spring-social-foursquare/src/main/java/org/springframework/social/foursquare/api/impl/FoursquareTemplate.java
@@ -43,7 +43,11 @@ public class FoursquareTemplate extends AbstractOAuth2ApiBinding implements Four
 	private ObjectMapper objectMapper;
 	
 	public FoursquareTemplate(String clientId, String clientSecret) {
-		this(clientId, clientSecret, null);
+		super();
+	        this.clientId = clientId;
+	        this.clientSecret = clientSecret;
+	        this.accessToken = null;
+	        initialize();
 	}
 	
 	public FoursquareTemplate(String clientId, String clientSecret, String accessToken) {


### PR DESCRIPTION
Fix FoursquareTemplate to accept Userless Access

If call constructor AbstractOAuth2ApiBinding(accessToken) it adds header Aythentication: Oauth <accessToken> even if pass null. In this case foursquare returns 400 Bad Request on user less requests
I changed constructor FoursquareTemplate() to use the default parent constructor.
